### PR TITLE
Fixed mobile nav toggler not working on production

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;700&display=swap" rel="stylesheet">
 
   <script defer src="./js/dropdown.js" type="module"></script>
-  <script defer src="./js/mobileNav.js"></script>
+  <script defer src="./js/mobileNav.js" type="module"></script>
 </head>
 
 <body>
@@ -28,7 +28,7 @@
       </a>
       <ul class="nav__list">
         <button class="btn btn-close">
-          <img src="/public/vectors/icon-close-menu.svg" alt="">
+          <img src="/vectors/icon-close-menu.svg" alt="">
         </button>
         <li class="nav__item relative">
           <button class="dropdown__btn" data-target="#features-dropdown">

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -1,9 +1,6 @@
 const dropdownToggles = document.querySelectorAll('.dropdown__btn')
 const dropdowns = document.querySelectorAll('.dropdown')
 
-console.log(dropdownToggles)
-console.log(dropdowns)
-
 dropdownToggles.forEach(toggle => {
   toggle.addEventListener('click', () => {
     const target = toggle.getAttribute('data-target')


### PR DESCRIPTION
It was a problem with the lack of `type="module"` when importing JavaScript in the HTML tag while using Vite for building